### PR TITLE
Issue fixed https://github.com/Triggertrap/SeekArc/issues/28

### DIFF
--- a/SeekArc_library/src/com/triggertrap/seekarc/SeekArc.java
+++ b/SeekArc_library/src/com/triggertrap/seekarc/SeekArc.java
@@ -268,10 +268,14 @@ public class SeekArc extends View {
 		// Draw the arcs
 		final int arcStart = mStartAngle + mAngleOffset + mRotation;
 		final int arcSweep = mSweepAngle;
-		canvas.drawArc(mArcRect, arcStart, arcSweep, false, mArcPaint);
-		canvas.drawArc(mArcRect, arcStart, mProgressSweep, false,
-				mProgressPaint);
-
+		if (mProgress == 0) {
+			canvas.drawArc(mArcRect, arcStart, arcSweep, false, mArcPaint);
+			
+		} else {
+			canvas.drawArc(mArcRect, arcStart, arcSweep, false, mArcPaint);
+   			canvas.drawArc(mArcRect, arcStart, mProgressSweep, false, mProgressPaint);
+			
+		}
 		// Draw the thumb nail
 		canvas.translate(mTranslateX - mThumbXPos, mTranslateY - mThumbYPos);
 		mThumb.draw(canvas);


### PR DESCRIPTION
@scottyab @neild001
fixed issue https://github.com/Triggertrap/SeekArc/issues/28
Seek Arc Issue only on S6 android version 5.1.1 

Update SeekArc.java

Seek Arc Issue only on S6 android version 5.1.1 
Whenever users having 0 points, seekarc is rotated to 360 degrees
